### PR TITLE
feat(utils): add result gatherers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,9 @@ exclude_patterns = []
 # Be strict about any broken references
 nitpicky = True
 
-nitpick_ignore = []
+nitpick_ignore = [
+    ("py:class", "sghi.etl.commons.utils.result_gatherers._T"),  # private type annotations
+]
 
 templates_path = ["templates"]
 

--- a/src/sghi/etl/commons/utils/__init__.py
+++ b/src/sghi/etl/commons/utils/__init__.py
@@ -1,0 +1,9 @@
+"""Common utilities."""
+
+from .result_gatherers import fail_fast, fail_fast_factory, ignored_failed
+
+__all__ = [
+    "fail_fast",
+    "fail_fast_factory",
+    "ignored_failed",
+]

--- a/src/sghi/etl/commons/utils/result_gatherers.py
+++ b/src/sghi/etl/commons/utils/result_gatherers.py
@@ -1,0 +1,165 @@
+"""Utilities for working with ``concurrent.futures.Future`` objects.
+
+This module provides helper functions for collecting results and/or errors from
+concurrent ``Future`` objects.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from concurrent.futures import Future
+from typing import TypeVar
+
+from sghi.utils import (
+    ensure_callable,
+    ensure_instance_of,
+    ensure_predicate,
+    future_succeeded,
+)
+
+# =============================================================================
+# TYPES
+# =============================================================================
+
+
+_T = TypeVar("_T")
+
+_ResultGatherer = Callable[[Iterable[Future[_T]]], Iterable[_T]]
+
+
+# =============================================================================
+# UTILITIES
+# =============================================================================
+
+
+def fail_fast(
+    futures: Iterable[Future[_T]],
+    exc_wrapper_factory: Callable[[str | None], BaseException] | None = None,
+    exc_wrapper_message: str | None = None,
+) -> Iterable[_T]:
+    """Return the results from futures or errors if any of the futures failed.
+
+    This function returns an ``Iterable`` of the results or errors(if any of
+    the futures failed) gathered from the provided
+    :class:`~concurrent.futures.Future` objects. Note that, this method by
+    itself doesn't raise any exceptions for valid input values, but rather,
+    consuming the returned ``Iterable`` is what raises the exception. When
+    iterating through the returned ``Iterable``, the exception will be raised
+    on the first encounter of a non-successful result. Optionally, a custom
+    exception type factory and message can be provided to be used when raising
+    the exception.
+
+    Essentially, this function maps each ``Future`` object to its result if it
+    completed successfully, or to a ``raise exp`` statement if the callable
+    wrapped by the ``Future`` raised an exception during execution. ``exp``
+    will either be the exception returned by ``exc_wrapper_factory`` function
+    when provided, or the original exception raised by the wrapped callable.
+
+    :param futures: An ``Iterable`` of ``Future`` objects to gather results
+        from.
+    :param exc_wrapper_factory: An optional ``Exception`` factory function. If
+        provided, the function will be used to create the actual exception
+        instance that will be raised, with the original exception attached as
+        the cause. That is, the original exception will be attached to the new
+        exception as the ``__cause__`` attribute.
+        When not provided, the original exception is raised as it is.
+    :param exc_wrapper_message: An optional message to use with the raised
+        exception. Note that this is only used if the ``exc_wrapper_factory``
+        parameter is also provided and ignored otherwise.
+        Defaults to ``None`` when not provided.
+
+    :return: An ``Iterable`` of the results gathered from the provided futures.
+
+    :raise TypeError: If ``futures`` is NOT an ``Iterable``.
+    :raise ValueError: If ``exc_wrapper_factory`` is provided but is NOT a
+        callable object.
+    """
+    ensure_instance_of(futures, Iterable, "'futures' MUST be an Iterable.")
+    ensure_predicate(
+        test=callable(exc_wrapper_factory) if exc_wrapper_factory else True,
+        message="When not None, 'exc_wrapper_factory' MUST be a callable.",
+    )
+
+    # Wrap the actual gathering operation in a nested function. This way, this
+    # entire function doesn't become a generator, and it can fail quickly when
+    # supplied with invalid arguments. That is, the "ensure_*" checks raise
+    # exceptions immediately on the invocation of this function if the checks
+    # fail instead of waiting until ``next`` is called on the returned
+    # generator.
+    def _do_gather() -> Iterable[_T]:
+        for future in futures:
+            try:
+                yield future.result()
+            except BaseException as exp:  # noqa: BLE001
+                if exc_wrapper_factory:
+                    raise exc_wrapper_factory(exc_wrapper_message) from exp
+                else:
+                    raise
+
+    return _do_gather()
+
+
+def fail_fast_factory(
+    exc_wrapper_factory: Callable[[str | None], BaseException],
+    exc_wrapper_message: str | None = None,
+) -> _ResultGatherer[_T]:
+    """Return a :func:`fail_fast` function that raises the specified exception.
+
+    Create and return a pre-configured :func:`fail_fast` function that raises
+    the specified exception and message.
+
+    :param exc_wrapper_factory: An ``Exception`` factory function that takes
+        an optional error message as input and returns an exception object to
+        be raised. The original exception will be attached to the created
+        exception as the ``__cause__`` attribute. This MUST be a valid callable
+        object.
+    :param exc_wrapper_message: An optional error message to use with the
+        raised exception. Defaults to ``None`` when not provided.
+
+    :return: A function that behaves as ``fail_fast`` but uses the specified
+        configuration.
+
+    :raise ValueError: If ``exc_wrapper_factory`` is NOT a callable object.
+    """
+    ensure_callable(
+        value=exc_wrapper_factory,
+        message="'exc_wrapper_factory' MUST be a callable.",
+    )
+
+    def _do_fail_fast(futures: Iterable[Future[_T]]) -> Iterable[_T]:
+        return fail_fast(
+            futures,
+            exc_wrapper_factory=exc_wrapper_factory,
+            exc_wrapper_message=exc_wrapper_message,
+        )
+
+    return _do_fail_fast
+
+
+def ignored_failed(futures: Iterable[Future[_T]]) -> Iterable[_T]:
+    """Return results only from successful futures.
+
+    Gather and return results from the successful futures of the provided set.
+    In this context, a ``Future`` is considered to have completed successfully
+    if it wasn't canceled and no uncaught exceptions were raised by its callee.
+
+    :param futures: An ``Iterable`` of ``Future`` objects to gather results
+        from.
+
+    :return: An ``Iterable`` of the results gathered from only the successful
+        futures of the provided set.
+
+    :raise TypeError: If ``futures`` is NOT an ``Iterable``.
+    """
+    ensure_instance_of(futures, Iterable, "'futures' MUST be an Iterable.")
+
+    # Wrap the actual gathering operation in a nested function. This way, this
+    # entire function doesn't become a generator, and it can fail quickly when
+    # supplied with invalid arguments. That is, the "ensure_*" checks raise
+    # exceptions immediately on the invocation of this function if the checks
+    # fail instead of waiting until ``next`` is called on the returned
+    # generator.
+    def _do_gather() -> Iterable[_T]:
+        yield from (ftr.result() for ftr in filter(future_succeeded, futures))
+
+    return _do_gather()

--- a/test/sghi/etl/commons_tests/utils_tests/__init__.py
+++ b/test/sghi/etl/commons_tests/utils_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ``sghi.etl.commons.utils`` package."""

--- a/test/sghi/etl/commons_tests/utils_tests/result_gatherers_tests.py
+++ b/test/sghi/etl/commons_tests/utils_tests/result_gatherers_tests.py
@@ -1,0 +1,211 @@
+"""Tests for the ``sghi.etl.commons.utils.result_gatherers`` module."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from concurrent.futures import Future
+
+import pytest
+
+from sghi.etl.commons.utils import fail_fast, fail_fast_factory, ignored_failed
+from sghi.exceptions import SGHIError
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def _create_successful_features(count: int = 5) -> Iterable[Future[int]]:
+    def _num_to_future(num: int) -> Future[int]:
+        f = Future()
+        f.set_result(num)
+        return f
+
+    yield from map(_num_to_future, range(count))
+
+
+def _create_futures_with_one_failed(
+    count: int = 5,
+    failed_index: int = 3,
+    exc_factory: Callable[[], BaseException] = SGHIError,
+) -> Iterable[Future[int]]:
+    def _num_to_future(num: int) -> Future[int]:
+        f = Future()
+        if num == failed_index:
+            f.set_exception(exc_factory())
+        else:
+            f.set_result(num)
+        return f
+
+    yield from map(_num_to_future, range(count))
+
+
+# =============================================================================
+# TEST CASES
+# =============================================================================
+
+
+def test_fail_fast_fails_when_given_invalid_args() -> None:
+    """:func:`sghi.etl.commons.utils.fail_fast` should fail when given invalid
+    args.
+    """  # noqa: D205
+    with pytest.raises(TypeError, match="MUST be an Iterable") as exp_info1:
+        fail_fast(None)  # type: ignore
+
+    with pytest.raises(ValueError, match="MUST be a callable") as exp_info2:
+        fail_fast(_create_successful_features(), exc_wrapper_factory="oops")  # type: ignore
+
+    assert exp_info1.value.args[0] == "'futures' MUST be an Iterable."
+    assert (
+        exp_info2.value.args[0]
+        == "When not None, 'exc_wrapper_factory' MUST be a callable."
+    )
+
+
+def test_fail_fast_returns_iterable_even_with_failed_futures_present() -> None:
+    """:func:`sghi.etl.commons.utils.fail_fast` should always return an
+    ``Iterable`` and not raise any exception for valid input args.
+
+    This should hold even if the any of the provided futures failed.
+    """  # noqa: D205
+    # noinspection PyBroadException
+    try:
+        results = fail_fast(
+            futures=_create_futures_with_one_failed(5, failed_index=2),
+        )
+    except BaseException:  # noqa: BLE001
+        fail_reason: str = (
+            "'fail_fast' should not raise any exception when given valid "
+            "inputs."
+        )
+        pytest.fail(fail_reason)
+
+    assert isinstance(results, Iterable)
+
+
+def test_fail_fast_return_value_when_futures_are_successful() -> None:
+    """:func:`sghi.etl.commons.utils.fail_fast` should return an ``Iterable``
+    of the gathered results if no future failed..
+    """  # noqa: D205
+    results = fail_fast(_create_successful_features(count=5))
+
+    assert isinstance(results, Iterable)
+    assert tuple(results) == (0, 1, 2, 3, 4)
+
+
+def test_fail_fast_return_value_with_failed_futures_no_exc_wrapper() -> None:
+    """:func:`sghi.etl.commons.utils.fail_fast` should return an ``Iterable``
+    of the gathered results and errors if any future failed.
+
+    Consuming the returned ``Iterable`` should raise an error at the first
+    encounter of the non-successful result.
+    """  # noqa: D205
+    results = fail_fast(_create_futures_with_one_failed(5, failed_index=2))
+
+    assert isinstance(results, Iterable)
+
+    results_iterator = iter(results)
+    assert next(results_iterator) == 0
+    assert next(results_iterator) == 1
+
+    with pytest.raises(SGHIError):
+        next(results_iterator)  # The third future(at index 2) failed.
+
+
+def test_fail_fast_return_value_with_failed_futures_and_exc_wrapper() -> None:
+    """:func:`sghi.etl.commons.utils.fail_fast` should return an ``Iterable``
+    of the gathered results and errors if any future failed.
+
+    Consuming the returned ``Iterable`` should raise an error at the first
+    encounter of the non-successful result. When ``exc_wrapper_factory`` is
+    provided, the raised error should be that returned by the factory with its
+    ``__cause__`` attribute set to the original error.
+    """  # noqa: D205
+    results = fail_fast(
+        futures=_create_futures_with_one_failed(5, failed_index=3),
+        exc_wrapper_factory=RuntimeError,
+    )
+
+    assert isinstance(results, Iterable)
+
+    results_iterator = iter(results)
+    assert next(results_iterator) == 0
+    assert next(results_iterator) == 1
+    assert next(results_iterator) == 2
+
+    with pytest.raises(RuntimeError) as exp_info:
+        next(results_iterator)
+
+    assert isinstance(exp_info.value.__cause__, SGHIError)
+
+
+def test_fail_fast_factory_fails_when_given_invalid_args() -> None:
+    """:func:`sghi.etl.commons.utils.fail_fast_factory` should raise a
+    :exc:`ValueError` when ``exc_wrapper_factory`` is not a callable object.
+    """  # noqa: D205
+    with pytest.raises(ValueError, match="MUST be a callable") as exp_info:
+        fail_fast_factory(exc_wrapper_factory="not a callable")  # type: ignore
+
+    assert (
+        exp_info.value.args[0] == "'exc_wrapper_factory' MUST be a callable."
+    )
+
+
+def test_fail_fast_factory_returns_expected_value() -> None:
+    """:func:`sghi.etl.commons.utils.fail_fast_factory` should return a
+    gatherer function with the same semantics as
+    :func:`sghi.etl.commons.utils.fail_fast`.
+
+    Consuming the returned ``Iterable`` should raise an error at the first
+    encounter of the non-successful result. The raised error should be that
+    returned by the provided ``exc_wrapper_factory`` factory with its
+    ``__cause__`` attribute set to the original error.
+    """  # noqa: D205
+    results1 = fail_fast_factory(
+        exc_wrapper_factory=RuntimeError,
+    )(_create_successful_features(5))
+
+    results2 = fail_fast_factory(
+        exc_wrapper_factory=RuntimeError, exc_wrapper_message="oops"
+    )(_create_futures_with_one_failed(5, failed_index=2))
+
+    assert isinstance(results1, Iterable)
+    assert isinstance(results2, Iterable)
+
+    assert tuple(results1) == (0, 1, 2, 3, 4)
+
+    results_iterator = iter(results2)
+    assert next(results_iterator) == 0
+    assert next(results_iterator) == 1
+
+    with pytest.raises(RuntimeError, match="oops") as exp_info:
+        next(results_iterator)  # The third future(at index 2) failed.
+
+    assert isinstance(exp_info.value.__cause__, SGHIError)
+
+
+def test_ignore_failed_fails_when_given_invalid_args() -> None:
+    """:func:`sghi.etl.commons.utils.ignore_failed` should raise a
+    :exc:`TypeError` when ``futures`` is not an ``Iterable`` object.
+    """  # noqa: D205
+    with pytest.raises(TypeError, match="MUST be an Iterable") as exp_info:
+        ignored_failed(None)  # type: ignore
+
+    assert exp_info.value.args[0] == "'futures' MUST be an Iterable."
+
+
+def test_ignore_failed_returns_expected_value() -> None:
+    """:func:`sghi.etl.commons.utils.ignore_failed` should return an
+    ``Iterable`` of the gathered results from successful futures of the
+    provided set.
+    """  # noqa: D205
+    results1 = ignored_failed(_create_successful_features(5))
+    results2 = ignored_failed(
+        _create_futures_with_one_failed(5, failed_index=2)
+    )
+
+    assert isinstance(results1, Iterable)
+    assert isinstance(results2, Iterable)
+
+    assert tuple(results1) == (0, 1, 2, 3, 4)
+    assert tuple(results2) == (0, 1, 3, 4)


### PR DESCRIPTION
Result gatherers are utilities for working with `concurrent.futures.Future` objects. They provide functionalities such as gathering results from ``Future`` objects and handling errors on failed futures.