### PR TITLE
chore(deps): upgrade project dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -13,14 +13,14 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
+    rev: v3.15.2
     hooks:
       - id: pyupgrade
         args:
         - --py311-plus
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.3.3
+    rev: v0.3.6
     hooks:
       - id: ruff
         args:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ exclude_patterns = []
 nitpicky = True
 
 nitpick_ignore = [
+    ("py:class", "concurrent.futures._base.Future"),  # sphinx can't find it
     ("py:class", "sghi.etl.commons.utils.result_gatherers._T"),  # private type annotations
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ classifiers = [
     "Typing :: Typed"
 ]
 dependencies = [
-    "typing-extensions>=4.9",
-    "sghi-commons @ git+https://github.com/savannahghi/sghi-commons.git@develop",
-    "sghi-etl-core @ git+https://github.com/savannahghi/sghi-etl-core.git@main",
+    "typing-extensions>=4.10.0",
+    "sghi-commons @ git+https://github.com/savannahghi/sghi-commons.git@v1.4.0",
+    "sghi-etl-core @ git+https://github.com/savannahghi/sghi-etl-core.git@v1.1.1",
 ]
 description = "Collection of utilities for working with SGHI ETL Worflows."
 dynamic = ["version"]
@@ -41,12 +41,12 @@ requires-python = ">=3.11" # Support Python 3.10+.
 
 [project.optional-dependencies]
 dev = [
-    "pre-commit~=3.6.2",
+    "pre-commit~=3.7.0",
 ]
 
 docs = [
     "furo==2024.1.29",
-    "jaraco.packaging~=9.4.0",
+    "jaraco.packaging~=9.5.0",
     "rst.linker~=2.4.0",
     "Sphinx~=7.2.6",
     "sphinx-favicon~=1.0.1",
@@ -60,20 +60,20 @@ test = [
     "coverage~=6.5.0",
     "coveralls~=3.3.1",
     "packaging",
-    "pyright>=1.1.353",
+    "pyright>=1.1.358",
     "pytest~=8.1.1",
-    "pytest-cov~=4.1.0",
+    "pytest-cov~=5.0.0",
     "pytest-forked~=1.6.0",
     "pytest-sugar~=1.0.0",
     "pytest-xdist~=3.5.0",
-    "ruff~=0.3.3",
-    "tox~=4.14.1",
+    "ruff~=0.3.6",
+    "tox~=4.14.2",
     "tox-gh-actions~=3.2.0",
 ]
 
 [project.urls]
-changelog = "https://github.com/savannahghi/sghi-etl-commons/blob/main/docs/CHANGELOG.md"
-documentation = "https://github.com/savannahghi/sghi-etl-commons/blob/main/README.md"
+changelog = "https://github.com/savannahghi/sghi-etl-commons/blob/develop/docs/CHANGELOG.md"
+documentation = "https://github.com/savannahghi/sghi-etl-commons/blob/develop/README.md"
 homepage = "https://github.com/savannahghi/sghi-etl-commons/"
 repository = "https://github.com/savannahghi/sghi-etl-commons.git"
 


### PR DESCRIPTION
Upgrade all dependencies except [coverage](https://github.com/nedbat/coveragepy). At the moment, `coverage` can't be upgraded to a version higher than 6.x as [coveralls-python](https://github.com/TheKevJames/coveralls-python) - a dependency of this project - has an upper bound on the supported `coverage` version. See this [issue](https://github.com/TheKevJames/coveralls-python/issues/373) for details. Moving forward, we should consider dropping `coveralls-python` as a dependency since it no longer appears to be maintained.