### PR TITLE
feat(sinks): add a `NullSink`

### DIFF
--- a/src/sghi/etl/commons/__init__.py
+++ b/src/sghi/etl/commons/__init__.py
@@ -1,12 +1,13 @@
 """Collection of utilities for working with SGHI ETL Workflows."""
 
 from .processors import NOOPProcessor, processor
-from .sinks import sink
+from .sinks import NullSink, sink
 from .sources import source
 from .utils import fail_fast, fail_fast_factory, ignored_failed
 
 __all__ = [
     "NOOPProcessor",
+    "NullSink",
     "fail_fast",
     "fail_fast_factory",
     "ignored_failed",

--- a/test/sghi/etl/commons_tests/sinks_tests.py
+++ b/test/sghi/etl/commons_tests/sinks_tests.py
@@ -4,11 +4,12 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest import TestCase
 
 import pytest
 
 from sghi.disposable import ResourceDisposedError
-from sghi.etl.commons import sink
+from sghi.etl.commons import NullSink, sink
 from sghi.etl.core import Sink
 
 if TYPE_CHECKING:
@@ -98,3 +99,70 @@ def test_sink_decorated_value_usage_when_is_disposed_fails() -> None:
 
     with pytest.raises(ResourceDisposedError):
         save_ints.__enter__()
+
+
+class TestNullSink(TestCase):
+    """Tests for the :class:`sghi.etl.commons.NullSInk` class."""
+
+    def test_dispose_has_the_intended_side_effects(self) -> None:
+        """Calling :meth:`NullSink.dispose` should result in the
+        :attr:`NullSink.is_disposed` property being set to ``True``.
+        """
+        instance = NullSink()
+        instance.dispose()
+
+        assert instance.is_disposed
+
+    def test_multiple_dispose_invocations_is_okay(self) -> None:
+        """Calling :meth:`NullSink.dispose` should be okay.
+
+        No errors should be raised and the object should remain disposed.
+        """
+        instance = NullSink()
+
+        for _ in range(10):
+            try:
+                instance.dispose()
+            except Exception as exc:  # noqa: BLE001
+                fail_reason: str = (
+                    "Calling 'NullSink.dispose()' multiple times should be "
+                    f"okay. But the following error was raised: {exc!s}"
+                )
+                pytest.fail(fail_reason)
+
+            assert instance.is_disposed
+
+    def test_usage_as_a_context_manager_behaves_as_expected(self) -> None:
+        """:class:`NullSink` instances are valid context managers and should
+        behave correctly when used as so.
+        """
+        processed_data: list[str] = [
+            "some",
+            "very",
+            "important",
+            "processed",
+            "data",
+        ]
+        with NullSink() as _sink:
+            _sink.drain(processed_data)
+
+        assert _sink.is_disposed
+
+    def test_usage_when_is_disposed_fails(self) -> None:
+        """Invoking "resource-aware" methods of a disposed instance should
+        result in an :exc:`ResourceDisposedError` being raised.
+
+        Specifically, invoking the following two methods on a disposed instance
+        should fail:
+
+        - :meth:`NullSink.__enter__`
+        - :meth:`NullSink.apply`
+        """
+        instance = NullSink()
+        instance.dispose()
+
+        with pytest.raises(ResourceDisposedError):
+            instance.drain("some processed data.")
+
+        with pytest.raises(ResourceDisposedError):
+            instance.__enter__()


### PR DESCRIPTION
Add `sghi.etl.commons.sinks.NullSink`, a `Sink` that discards all the data it receives. This is mostly useful as a placeholder or where consumption of processed data is not required.