### PR TITLE
feat(processors): add a `ScatterGatherProcessor`

### DIFF
--- a/src/sghi/etl/commons/__init__.py
+++ b/src/sghi/etl/commons/__init__.py
@@ -3,6 +3,7 @@
 from .processors import (
     NOOPProcessor,
     ProcessorPipe,
+    ScatterGatherProcessor,
     SplitGatherProcessor,
     pipe_processors,
     processor,
@@ -18,6 +19,7 @@ __all__ = [
     "NullSink",
     "ProcessorPipe",
     "SimpleWorkflowDefinition",
+    "ScatterGatherProcessor",
     "SplitGatherProcessor",
     "fail_fast",
     "fail_fast_factory",


### PR DESCRIPTION
Add `sghi.etl.commons.processors.ScatterGatherProcessor`, a `Processor` that applies multiple other processors to the same raw data, and then returns the aggregated outputs of these processors.