### PR TITLE
feat(sinks): add a `ScatterSink`

### DIFF
--- a/src/sghi/etl/commons/__init__.py
+++ b/src/sghi/etl/commons/__init__.py
@@ -8,7 +8,7 @@ from .processors import (
     pipe_processors,
     processor,
 )
-from .sinks import NullSink, SplitSink, sink
+from .sinks import NullSink, ScatterSink, SplitSink, sink
 from .sources import GatherSource, source
 from .utils import fail_fast, fail_fast_factory, ignored_failed
 from .workflow_definitions import SimpleWorkflowDefinition
@@ -20,6 +20,7 @@ __all__ = [
     "ProcessorPipe",
     "SimpleWorkflowDefinition",
     "ScatterGatherProcessor",
+    "ScatterSink",
     "SplitGatherProcessor",
     "SplitSink",
     "fail_fast",

--- a/test/sghi/etl/commons_tests/sinks_tests.py
+++ b/test/sghi/etl/commons_tests/sinks_tests.py
@@ -10,7 +10,7 @@ import pytest
 from typing_extensions import override
 
 from sghi.disposable import ResourceDisposedError
-from sghi.etl.commons import NullSink, SplitSink, sink
+from sghi.etl.commons import NullSink, ScatterSink, SplitSink, sink
 from sghi.etl.core import Sink
 
 if TYPE_CHECKING:
@@ -167,6 +167,185 @@ class TestNullSink(TestCase):
 
         with pytest.raises(ResourceDisposedError):
             instance.__enter__()
+
+
+class TestScatterSink(TestCase):
+    """Tests for the :class:`sghi.etl.commons.ScatterSink` class."""
+
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+        self._repository1: MutableSequence[int] = []
+        self._repository2: MutableSet[int] = set()
+
+        @sink
+        def save_ordered(values: Iterable[int]) -> None:
+            self._repository1.extend(values)
+
+        @sink
+        def save_randomly(values: Iterable[int]) -> None:
+            for value in values:
+                self._repository2.add(value)
+
+        self._embedded_sinks: Sequence[Sink[Iterable[int]]] = [
+            save_ordered,
+            save_randomly,
+        ]
+        self._instance: ScatterSink[Iterable[int]]
+        self._instance = ScatterSink(self._embedded_sinks)
+
+    @override
+    def tearDown(self) -> None:
+        super().tearDown()
+        self._instance.dispose()
+
+    def test_dispose_has_the_intended_side_effects(self) -> None:
+        """Calling :meth:`ScatterSink.dispose` should result in the
+        :attr:`ScatterSink.is_disposed` property being set to ``True``.
+
+        Each embedded ``Sink`` should also be disposed.
+        """
+        self._instance.dispose()
+
+        assert self._instance.is_disposed
+        for _sink in self._embedded_sinks:
+            assert _sink.is_disposed
+
+    def test_drain_side_effects(self) -> None:
+        """:meth:`ScatterSink.drain` should drain the supplied processed data
+        to all embedded sinks.
+        """
+        self._instance.drain(list(range(5)))
+
+        assert len(self._repository1) == 5
+        assert len(self._repository2) == 5
+        assert self._repository1[0] == 0
+        assert self._repository1[1] == 1
+        assert self._repository1[2] == 2
+        assert self._repository1[3] == 3
+        assert 0 in self._repository2
+        assert 1 in self._repository2
+        assert 2 in self._repository2
+        assert 3 in self._repository2
+
+    def test_instantiation_fails_on_an_empty_processors_arg(self) -> None:
+        """Instantiating a :class:`ScatterSink` with an empty ``sinks``
+        argument should raise a :exc:`ValueError`.
+        """
+        with pytest.raises(ValueError, match="NOT be empty") as exp_info:
+            ScatterSink(sinks=[])
+
+        assert exp_info.value.args[0] == "'sinks' MUST NOT be empty."
+
+    def test_instantiation_fails_on_non_callable_executor_factory_arg(
+        self,
+    ) -> None:
+        """Instantiating a :class:`ScatterSink` with a non-callable value for
+        the ``executor_factory`` argument should raise a :exc:`ValueError`.
+        """
+        with pytest.raises(ValueError, match="MUST be a callable") as exp_info:
+            ScatterSink(sinks=self._embedded_sinks, executor_factory=None)  # type: ignore
+
+        assert (
+            exp_info.value.args[0] == "'executor_factory' MUST be a callable."
+        )
+
+    def test_instantiation_fails_on_non_callable_result_gatherer_arg(
+        self,
+    ) -> None:
+        """Instantiating a :class:`ScatterSink` with a non-callable value for
+        the ``result_gatherer`` argument should raise a :exc:`ValueError`.
+        """
+        with pytest.raises(ValueError, match="MUST be a callable") as exp_info:
+            ScatterSink(sinks=self._embedded_sinks, result_gatherer=None)  # type: ignore
+
+        assert (
+            exp_info.value.args[0] == "'result_gatherer' MUST be a callable."
+        )
+
+    def test_instantiation_fails_on_non_callable_retry_policy_factory_arg(
+        self,
+    ) -> None:
+        """Instantiating a :class:`ScatterSink` with a non-callable value for
+        the ``retry_policy_factory`` argument should raise a :exc:`ValueError`.
+        """
+        with pytest.raises(ValueError, match="MUST be a callable") as exp_info:
+            ScatterSink(sinks=self._embedded_sinks, retry_policy_factory=None)  # type: ignore
+
+        assert (
+            exp_info.value.args[0]
+            == "'retry_policy_factory' MUST be a callable."
+        )
+
+    def test_instantiation_fails_on_non_sequence_sinks_arg(self) -> None:
+        """Instantiating a :class:`ScatterSink` with a non ``Sequence``
+        ``sinks`` argument should raise a :exc:`TypeError`.
+        """
+        values = (None, 67, self._embedded_sinks[0])
+        for value in values:
+            with pytest.raises(TypeError, match="Sequence") as exp_info:
+                ScatterSink(sinks=value)  # type: ignore
+
+            assert (
+                exp_info.value.args[0]
+                == "'sinks' MUST be a collections.abc.Sequence object."
+            )
+
+    def test_multiple_dispose_invocations_is_okay(self) -> None:
+        """Calling :meth:`ScatterSink.dispose` multiple times should be okay.
+
+        No errors should be raised and the object should remain disposed.
+        """
+        for _ in range(10):
+            try:
+                self._instance.dispose()
+            except Exception as exc:  # noqa: BLE001
+                fail_reason: str = (
+                    "Calling 'ScatterSink.dispose()' multiple times should be "
+                    f"okay. But the following error was raised: {exc!s}"
+                )
+                pytest.fail(fail_reason)
+
+            assert self._instance.is_disposed
+            for _sinks in self._embedded_sinks:
+                assert _sinks.is_disposed
+
+    def test_usage_as_a_context_manager_behaves_as_expected(self) -> None:
+        """:class:`ScatterSink` instances are valid context managers and should
+        behave correctly when used as so.
+        """
+        with self._instance:
+            self._instance.drain([-100, 60, 0])
+            assert len(self._repository1) == 3
+            assert len(self._repository2) == 3
+            assert self._repository1[0] == -100
+            assert self._repository1[1] == 60
+            assert self._repository1[2] == 0
+            assert -100 in self._repository2
+            assert 60 in self._repository2
+            assert 0 in self._repository2
+
+        assert self._instance.is_disposed
+        for _sink in self._embedded_sinks:
+            assert _sink.is_disposed
+
+    def test_usage_when_is_disposed_fails(self) -> None:
+        """Invoking "resource-aware" methods of a disposed instance should
+        result in an :exc:`ResourceDisposedError` being raised.
+
+        Specifically, invoking the following two methods on a disposed instance
+        should fail:
+
+        - :meth:`ScatterSink.__enter__`
+        - :meth:`ScatterSink.drain`
+        """
+        self._instance.dispose()
+
+        with pytest.raises(ResourceDisposedError):
+            self._instance.drain([10, 10, 0])
+
+        with pytest.raises(ResourceDisposedError):
+            self._instance.__enter__()
 
 
 class TestSplitSink(TestCase):


### PR DESCRIPTION
Add `sghi.etl.commons.sink.ScatterSink`, a `Sink` that drains (the same) processed data to multiple other sinks concurrently.