### PR TITLE
feat(core): add support for `prologue` and `epilogue` workflow properties

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,8 @@ exclude_patterns = []
 nitpicky = True
 
 nitpick_ignore = [
+    ("py:attr", "sghi.etl.core.WorkflowDefinition.epilogue"),  # docs aren't published yet
+    ("py:attr", "sghi.etl.core.WorkflowDefinition.prologue"),  # docs aren't published yet
     ("py:attr", "sghi.etl.core.WorkflowDefinition.processor_factory"),  # docs aren't published yet
     ("py:attr", "sghi.etl.core.WorkflowDefinition.sink_factory"),  # docs aren't published yet
     ("py:attr", "sghi.etl.core.WorkflowDefinition.source_factory"),  # docs aren't published yet

--- a/src/sghi/etl/commons/workflow_definitions.py
+++ b/src/sghi/etl/commons/workflow_definitions.py
@@ -34,6 +34,15 @@ _RDT = TypeVar("_RDT")
 
 
 # =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def _noop() -> None:
+    """Do nothing."""
+
+
+# =============================================================================
 # SPEC IMPLEMENTATIONS
 # =============================================================================
 
@@ -45,6 +54,17 @@ class SimpleWorkflowDefinition(
 ):
     """A simple :class:`WorkflowDefinition` implementation."""
 
+    __slots__ = (
+        "_description",
+        "_epilogue",
+        "_id",
+        "_name",
+        "_processor_factory",
+        "_prologue",
+        "_sink_factory",
+        "_source_factory",
+    )
+
     def __init__(  # noqa: PLR0913
         self,
         id: str,  # noqa: A002
@@ -53,6 +73,8 @@ class SimpleWorkflowDefinition(
         description: str | None = None,
         processor_factory: Callable[[], Processor[_RDT, _PDT]] = NOOPProcessor,
         sink_factory: Callable[[], Sink[_PDT]] = NullSink,
+        prologue: Callable[[], None] = _noop,
+        epilogue: Callable[[], None] = _noop,
     ) -> None:
         """Create a new ``WorkflowDefinition`` with the provided properties.
 
@@ -77,13 +99,20 @@ class SimpleWorkflowDefinition(
         :param sink_factory: A function that suppliers the ``Sink`` associated
             with the created workflow. This MUST be a valid callable. Defaults
             to ``NullSink`` when not provided.
+        :param prologue: An optional function to be invoked at the beginning of
+            the created workflow. This MUST be a valid callable. Defaults to
+            a callable that does nothing when invoked.
+        :param epilogue: An optional function to be invoked at the end of the
+            created workflow. This MUST be a valid callable. Defaults to
+            a callable that does nothing when invoked.
 
         :raise TypeError: If ``id`` or ``name`` are NOT strings, or if
             ``description`` is provided but is NOT a string.
         :raise ValueError: If one of the following is ``True``; ``id`` is an
             empty string, ``name`` is an empty string, ``source_factory`` is
             NOT a valid callable, ``processor_factory`` is NOT a valid callable
-            or ``sink_factory`` is NOT a valid callable.
+            , ``sink_factory`` is NOT a valid callable, ``prologue`` is NOT a
+            valid callable or ``epilogue`` is NOT a valid callable.
         """
         super().__init__()
         self._id: str = ensure_not_none_nor_empty(
@@ -120,6 +149,14 @@ class SimpleWorkflowDefinition(
             value=sink_factory,
             message="'sink_factory' MUST be a callable object.",
         )
+        self._prologue: Callable[[], None] = ensure_callable(
+            value=prologue,
+            message="'prologue' MUST be a callable object.",
+        )
+        self._epilogue: Callable[[], None] = ensure_callable(
+            value=epilogue,
+            message="'epilogue' MUST be a callable object.",
+        )
 
     @property
     @override
@@ -150,6 +187,33 @@ class SimpleWorkflowDefinition(
     @override
     def sink_factory(self) -> Callable[[], Sink[_PDT]]:
         return self._sink_factory
+
+    @property
+    @override
+    def prologue(self) -> Callable[[], None]:
+        """A callable to be executed at the beginning of the workflow.
+
+        If the execution of this callable fails, i.e. raises an exception, then
+        the main workflow is never executed, only the callable returned by the
+        :attr:`epilogue` property is.
+        This can be used to validate the loaded configuration, setting up
+        certain resources before the workflow execution starts, etc.
+
+        .. versionadded:: 1.2.0
+        """
+        return self._prologue
+
+    @property
+    @override
+    def epilogue(self) -> Callable[[], None]:
+        """A callable to be executed at the end of the workflow.
+
+        This is always executed regardless of whether the resulting workflow
+        or its :attr:`prologue` callable completed successfully.
+
+        .. versionadded:: 1.2.0
+        """
+        return self._epilogue
 
 
 # =============================================================================

--- a/test/sghi/etl/commons_tests/utils_tests/others_tests.py
+++ b/test/sghi/etl/commons_tests/utils_tests/others_tests.py
@@ -12,6 +12,7 @@ from sghi.etl.commons import (
     NullSink,
     ProcessorPipe,
     SimpleWorkflowDefinition,
+    WorkflowBuilder,
     processor,
     run_workflow,
     sink,
@@ -28,41 +29,49 @@ if TYPE_CHECKING:
 # =============================================================================
 
 
-def _workflow_factory_generator(
+def _noop() -> None:
+    """Do nothing."""
+
+
+def _create_workflow_factory(  # noqa: PLR0913
     repository: MutableSequence[str],
     start: int = 0,
     stop: int = 5,
     step: int = 1,
+    prologue: Callable[[], None] = _noop,
+    epilogue: Callable[[], None] = _noop,
 ) -> Callable[[], WorkflowDefinition[Iterable[int], Iterable[str]]]:
+    wb: WorkflowBuilder[Iterable[int], Iterable[str]]
+    wb = WorkflowBuilder(
+        id="test_workflow",
+        name="Test Workflow",
+        composite_processor_factory=ProcessorPipe,
+        prologue=prologue,
+        epilogue=epilogue,
+    )
+
+    @wb.draws_from
     @source
-    def supply_ints() -> Iterable[int]:
+    def supply_ints() -> Iterable[int]:  # pyright: ignore[reportUnusedFunction]
         yield from range(start, stop, step)
 
+    @wb.applies_processor
     @processor
-    def add_100(values: Iterable[int]) -> Iterable[int]:
+    def add_100(values: Iterable[int]) -> Iterable[int]:  # pyright: ignore[reportUnusedFunction]
         for v in values:
             yield v + 100
 
+    @wb.applies_processor
     @processor
-    def ints_as_strings(ints: Iterable[int]) -> Iterable[str]:
+    def ints_as_strings(ints: Iterable[int]) -> Iterable[str]:  # pyright: ignore[reportUnusedFunction]
         yield from map(str, ints)
 
+    @wb.drains_to
     @sink
-    def save_strings_to_repo(strings: Iterable[str]) -> None:
+    def save_strings_to_repo(strings: Iterable[str]) -> None:  # pyright: ignore[reportUnusedFunction]
         repository.extend(strings)
 
-    def _create_workflow() -> WorkflowDefinition[Iterable[int], Iterable[str]]:
-        return SimpleWorkflowDefinition(
-            id="test_workflow",
-            name="Test Workflow",
-            source_factory=lambda: supply_ints,
-            processor_factory=lambda: ProcessorPipe(
-                [add_100, ints_as_strings],
-            ),
-            sink_factory=lambda: save_strings_to_repo,
-        )
-
-    return _create_workflow
+    return wb
 
 
 # =============================================================================
@@ -74,7 +83,7 @@ def test_run_workflow_fails_on_non_callable_input() -> None:
     """:func:`sghi.etl.commons.utils.run_workflow` should raise a
     :exc:`ValueError` when given a non-callable input value.
     """
-    wf = _workflow_factory_generator([])
+    wf = _create_workflow_factory([])
     for non_callable in (None, wf()):
         with pytest.raises(ValueError, match="callable object.") as exp_info:
             run_workflow(wf=non_callable)  # type: ignore[reportArgumentType]
@@ -84,12 +93,56 @@ def test_run_workflow_fails_on_non_callable_input() -> None:
         )
 
 
-def test_run_workflow_side_effects_on_failed_execution() -> None:
+def test_run_workflow_side_effects_on_failed_drain() -> None:
     """:func:`sghi.etl.commons.utils.run_workflow` should dispose all the
-    workflow components (source, processor and sink) if an error occurs during
-    execution.
+    workflow components (source, processor and sink) and invoke the
+    ``epilogue`` callable of the workflow if an error occurs while draining
+    data to a :class:`Sink`.
     """
 
+    @source
+    def greate_the_world() -> str:
+        return "Hello World!!"
+
+    @sink
+    def failing_sink(_: str) -> None:
+        _err_msg: str = "Oops, something failed."
+        raise RuntimeError(_err_msg)
+
+    _processor = NOOPProcessor()
+    _has_cleaned_up: bool = False
+
+    def clean_up() -> None:
+        nonlocal _has_cleaned_up
+        _has_cleaned_up = True
+
+    def create_failing_workflow() -> WorkflowDefinition[str, str]:
+        return SimpleWorkflowDefinition(
+            id="failing_workflow",
+            name="Failing Workflow",
+            source_factory=lambda: greate_the_world,
+            processor_factory=lambda: _processor,
+            sink_factory=lambda: failing_sink,
+            epilogue=clean_up,
+        )
+
+    with pytest.raises(RuntimeError, match="Oops, something failed."):
+        run_workflow(wf=create_failing_workflow)
+
+    assert greate_the_world.is_disposed
+    assert _processor.is_disposed
+    assert failing_sink.is_disposed
+    assert _has_cleaned_up
+
+
+def test_run_workflow_side_effects_on_failed_draw() -> None:
+    """:func:`sghi.etl.commons.utils.run_workflow` should dispose all the
+    workflow components (source, processor and sink) and invoke the
+    ``epilogue`` callable of the workflow if an error occurs while drawing data
+    rom a :class:`Source`.
+    """
+
+    # noinspection PyTypeChecker
     @source
     def failing_source() -> str:
         _err_msg: str = "Oops, something failed."
@@ -97,6 +150,11 @@ def test_run_workflow_side_effects_on_failed_execution() -> None:
 
     _processor = NOOPProcessor()
     _sink = NullSink()
+    _has_cleaned_up: bool = False
+
+    def clean_up() -> None:
+        nonlocal _has_cleaned_up
+        _has_cleaned_up = True
 
     def create_failing_workflow() -> WorkflowDefinition[str, str]:
         return SimpleWorkflowDefinition(
@@ -105,6 +163,7 @@ def test_run_workflow_side_effects_on_failed_execution() -> None:
             source_factory=lambda: failing_source,
             processor_factory=lambda: _processor,
             sink_factory=lambda: _sink,
+            epilogue=clean_up,
         )
 
     with pytest.raises(RuntimeError, match="Oops, something failed."):
@@ -113,19 +172,105 @@ def test_run_workflow_side_effects_on_failed_execution() -> None:
     assert failing_source.is_disposed
     assert _processor.is_disposed
     assert _sink.is_disposed
+    assert _has_cleaned_up
+
+
+def test_run_workflow_side_effects_on_failed_processing() -> None:
+    """:func:`sghi.etl.commons.utils.run_workflow` should dispose all the
+    workflow components (source, processor and sink) and invoke the
+    ``epilogue`` callable of the workflow if an error occurs while processing
+    data.
+    """
+
+    @source
+    def greate_the_world() -> str:
+        return "Hello World!!"
+
+    # noinspection PyTypeChecker
+    @processor
+    def failing_processor(_: str) -> str:
+        _err_msg: str = "Oops, something failed."
+        raise RuntimeError(_err_msg)
+
+    _sink = NullSink()
+    _has_cleaned_up: bool = False
+
+    def clean_up() -> None:
+        nonlocal _has_cleaned_up
+        _has_cleaned_up = True
+
+    def create_failing_workflow() -> WorkflowDefinition[str, str]:
+        return SimpleWorkflowDefinition(
+            id="failing_workflow",
+            name="Failing Workflow",
+            source_factory=lambda: greate_the_world,
+            processor_factory=lambda: failing_processor,
+            sink_factory=lambda: _sink,
+            epilogue=clean_up,
+        )
+
+    with pytest.raises(RuntimeError, match="Oops, something failed."):
+        run_workflow(wf=create_failing_workflow)
+
+    assert greate_the_world.is_disposed
+    assert failing_processor.is_disposed
+    assert _sink.is_disposed
+    assert _has_cleaned_up
+
+
+def test_run_workflow_side_effects_on_failed_prologue_execution() -> None:
+    """:func:`sghi.etl.commons.utils.run_workflow` should  invoke the
+    ``epilogue`` callable of the workflow if an error occurs while executing
+    the ``prologue`` callable of the workflow.
+    """
+
+    def failing_prologue() -> None:
+        _err_msg: str = "Oops, something failed."
+        raise RuntimeError(_err_msg)
+
+    _has_cleaned_up: bool = False
+
+    def clean_up() -> None:
+        nonlocal _has_cleaned_up
+        _has_cleaned_up = True
+
+    wf = _create_workflow_factory(
+        repository=[],
+        prologue=failing_prologue,
+        epilogue=clean_up,
+    )
+
+    with pytest.raises(RuntimeError, match="Oops, something failed."):
+        run_workflow(wf)
+
+    assert _has_cleaned_up
 
 
 def test_run_workflow_side_effects_on_successful_execution() -> None:
     """func:`sghi.etl.commons.utils.run_workflow` should execute an ETL
     Workflow when given a factory function that returns the workflow.
     """
+    has_set_up: bool = False
+    has_cleaned_up: bool = False
+
+    def set_up() -> None:
+        nonlocal has_set_up
+        has_set_up = True
+
+    def clean_up() -> None:
+        nonlocal has_cleaned_up
+        has_cleaned_up = True
+
     repository1: list[str] = []
     repository2: list[str] = []
-    wf1 = _workflow_factory_generator(repository1)
-    wf2 = _workflow_factory_generator(repository2, 10, 60, 10)
+
+    wf1 = _create_workflow_factory(repository1)
+    wf2 = _create_workflow_factory(repository2, 10, 60, 10, set_up, clean_up)
 
     run_workflow(wf1)
     run_workflow(wf2)
 
     assert repository1 == ["100", "101", "102", "103", "104"]
     assert repository2 == ["110", "120", "130", "140", "150"]
+    assert has_cleaned_up
+    assert has_set_up

--- a/test/sghi/etl/commons_tests/workflow_definitions_tests.py
+++ b/test/sghi/etl/commons_tests/workflow_definitions_tests.py
@@ -36,6 +36,10 @@ def _ints_to_str_mapper_factory() -> Processor[Iterable[int], Iterable[str]]:
     return ints_to_str
 
 
+def _noop() -> None:
+    """Do nothing."""
+
+
 def _printer_factory() -> Sink[Iterable[Any]]:
     return sink(print)
 
@@ -60,6 +64,8 @@ class TestSimpleWorkflowDefinitions(TestCase):
             description="A test workflow that takes ints and prints all them.",
             processor_factory=_ints_to_str_mapper_factory,
             sink_factory=_printer_factory,
+            epilogue=_noop,
+            prologue=_noop,
         )
 
         assert wf_def.id == "test_workflow"
@@ -68,9 +74,11 @@ class TestSimpleWorkflowDefinitions(TestCase):
             wf_def.description
             == "A test workflow that takes ints and prints all them."
         )
+        assert wf_def.prologue is _noop
         assert wf_def.source_factory is _ints_supplier_factory
         assert wf_def.processor_factory is _ints_to_str_mapper_factory
         assert wf_def.sink_factory is _printer_factory
+        assert wf_def.epilogue is _noop
 
     def test_instantiation_fails_on_none_str_id_argument(self) -> None:
         """Instantiating a :class:`SimpleWorkflowDefinition` with a non-string


### PR DESCRIPTION
This builds on [this changes](https://github.com/savannahghi/sghi-etl-core/pull/22) on the core library by adding `prologue` and `epilogue` properties to `sghi.etl.core.WorkfowDefinition` implementations and adds support for working with these properties on existing runners.